### PR TITLE
Update batch mode to not load entire h5 file

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -103,11 +103,10 @@ async def detect_coastal_info(
         if not request.batch_mode:
             # Single coordinate processing
             with time_operation(TimerOperations.TotalSingleLookup):
-                distance_m, land_class_id, nearest_point = pipeline_main(
+                distance_m, land_cover_class, nearest_point = pipeline_main(
                     request.lat, request.lon
                 )
 
-            land_cover_class = land_water_mapping.get(land_class_id, LandCoverClass.Unknown)
             logger.info("Land cover class: %s", land_cover_class)
             logger.info("Distance to coast: %d m", distance_m)
 

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -234,7 +234,8 @@ def process_batch(
         return distances_m, land_classes, nearest_points
 
     # Load HDF5 data
-    land_classes = h5_to_landcover(tile_file, lats, lons)
+    with time_operation(TimerOperations.LoadH5File):
+        land_classes = h5_to_landcover(tile_file, lats, lons)
 
     # BallTree query
     if balltree_file is not None:

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -175,7 +175,7 @@ def get_h5_data(tile_filename: str) -> tuple[NDArray, rasterio.transform.Affine]
             if geotransform.shape[0] > 6:
                 geotransform = geotransform[:6]
 
-            band_data_arr = band_data[()]
+            band_data_arr = band_data[()]  # Load into memory
     return band_data_arr, rasterio.transform.Affine(*geotransform)
 
 

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -320,7 +320,7 @@ def batch_main(lat: np.ndarray, lon: np.ndarray) -> pd.DataFrame:
             distance_m, nearest_point = coord_to_coastal_point(la, lo)
             # Ocean => land_class = 0
             dist_list.append(distance_m)
-            lc_list.append(LandCoverClass.Unknown)
+            lc_list.append(LandCoverClass.PermanentWaterBodies)
             nearest_lat_list.append(nearest_point[0])
             nearest_lon_list.append(nearest_point[1])
 
@@ -364,7 +364,7 @@ def main(lat: float, lon: float) -> tuple[float, LandCoverClass, NDArray[np.floa
             )
             if new_filename_h5 is None:
                 # No tile for nearest coastal point, ocean fallback
-                return distance_m, LandCoverClass.Unknown, nearest_point
+                return distance_m, LandCoverClass.PermanentWaterBodies, nearest_point
             filename_ball_tree = new_filename_h5.replace(".h5", ball_tree_suffix)
             tile_ball_tree = get_ball_tree(filename_ball_tree)
             distance_m, nearest_point = ball_tree_distance(tile_ball_tree, [lat, lon])
@@ -372,7 +372,7 @@ def main(lat: float, lon: float) -> tuple[float, LandCoverClass, NDArray[np.floa
     else:
         # Ocean fallback for single point
         distance_m, nearest_point = coord_to_coastal_point(lat, lon)
-        return distance_m, LandCoverClass.Unknown, nearest_point
+        return distance_m, LandCoverClass.PermanentWaterBodies, nearest_point
 
 
 if __name__ == "__main__":

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -227,9 +227,9 @@ def process_batch(
         # Ocean case
         tree = initialize_coastal_ball_tree()
         distances_m, nearest_points = ball_tree_distance_batch(tree, lats, lons)
-        # Explicitly handle ocean case with zeros array
+        # Explicitly handle ocean case
         land_classes = np.full_like(
-            distances_m, LandCoverClass.Unknown, dtype=int
+            distances_m, LandCoverClass.PermanentWaterBodies, dtype=int
         ).tolist()
         return distances_m, land_classes, nearest_points
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -89,7 +89,7 @@ def test_land_water_mapping_values() -> None:
 def test_main_with_different_locations(
     lat: float,
     lon: float,
-    expected_class: int,
+    expected_class: LandCoverClass,
     description: str,
     mock_ball_tree: BallTree,
 ) -> None:
@@ -100,8 +100,8 @@ def test_main_with_different_locations(
             return_value="test.h5",
         ),
         patch(
-            "pipeline.h5_to_integer",
-            return_value=expected_class,
+            "pipeline.h5_to_landcover",
+            return_value=[expected_class],
         ),
         patch(
             "pipeline.get_ball_tree",
@@ -213,7 +213,7 @@ def test_ball_tree_distance(mock_ball_tree: BallTree) -> None:
 
 
 @patch("pipeline.get_filename_for_coordinates")
-@patch("pipeline.h5_to_integer")
+@patch("pipeline.h5_to_landcover")
 @patch("pipeline.get_ball_tree")
 @patch("pipeline.ball_tree_distance")
 def test_main(
@@ -226,7 +226,7 @@ def test_main(
     """Test main pipeline function."""
     # Setup mocks
     mock_filename.return_value = "test.h5"
-    mock_h5.return_value = 50  # Built-up area
+    mock_h5.return_value = [LandCoverClass.BuiltUp]
     mock_get_tree.return_value = mock_ball_tree
     mock_distance.return_value = (100.0, np.array([47.6, -122.3]))
 
@@ -236,13 +236,13 @@ def test_main(
     assert len(result) == 3
     distance, land_class, nearest = result
     assert isinstance(distance, float)
-    assert isinstance(land_class, int)
+    assert isinstance(land_class, LandCoverClass)
     assert isinstance(nearest, np.ndarray)
 
     # Test point in ocean
     mock_filename.return_value = None
     result = main(0.0, -160.0)
-    assert result[1] == 0  # Should be water
+    assert result[1] == LandCoverClass.PermanentWaterBodies  # Should be water
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -208,7 +208,7 @@ def test_h5_to_integer(
         0,
     )  # Mock row, col result
 
-    land_class = h5_to_integer("test.h5", TEST_LON, TEST_LAT)
+    land_class = h5_to_integer("test.h5", 0.00, 0.00)
     assert isinstance(land_class, int)
     assert 0 <= land_class <= 100
 


### PR DESCRIPTION
Loading the h5 files from disk is taking the majority of the time for lookup operations, while the ball tree lookups are quite quick.   I'm hoping that adding the same cache around the h5 files helps this out. 

Here is the prometheus metrics showing the average time per operation.  showing that loading the h5 files is a significant percentage of the time per batch lookup: 
![Screenshot from 2025-03-19 10-50-22](https://github.com/user-attachments/assets/160de13f-cdd5-4734-87a9-87be2e427792)


Just running the little simple main method in pipeline.py shows a ~18x speed up: 

**The current main branch:**
```
2025-03-20 16:51:19,048 - __main__ - INFO - Single query result: 275.98045427789 meters to coast, land cover class: Permanent water bodies, nearest coastal point: [  47.637417 -122.338585]
2025-03-20 16:51:19,048 - __main__ - INFO - Processing time: 0.011995 seconds
2025-03-20 16:51:19,324 - __main__ - INFO - Batch query results:
      distance_m  land_class  nearest_lat  nearest_lon
0     275.980454          80    47.637417  -122.338585
1     272.581267          80    47.637417  -122.338585
2  572994.031583           0     4.759158    -1.978242
2025-03-20 16:51:19,327 - __main__ - INFO - Batch processing time: 0.279263 seconds
```

**This PR**
```
2025-03-20 16:50:42,876 - __main__ - INFO - Single query result: 275.98045427789 meters to coast, land cover class: Permanent water bodies, nearest coastal point: [  47.637417 -122.338585]
2025-03-20 16:50:42,876 - __main__ - INFO - Processing time: 0.012735 seconds
2025-03-20 16:50:42,888 - __main__ - INFO - Batch query results:
      distance_m              land_class  nearest_lat  nearest_lon
0     275.980454  Permanent water bodies    47.637417  -122.338585
1     272.581267  Permanent water bodies    47.637417  -122.338585
2  572994.031583                 Unknown     4.759158    -1.978242
2025-03-20 16:50:42,891 - __main__ - INFO - Batch processing time: 0.014743 seconds
```
